### PR TITLE
Support cross-platform builds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "ustwds",
-  "version": "1.0.0",
+  "name": "@hursey013/tailwindcss-uswds",
+  "version": "1.0.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "author": "Brian Hurst",
   "license": "MIT",
   "scripts": {
-    "build:clean": "rm -rf build",
+    "build:clean": "rimraf build",
     "prebuild": "npm run build:clean",
     "build": "node scripts/build.js",
     "postinstall": "npm run build"
@@ -27,5 +27,7 @@
     "url": "https://github.com/hursey013/tailwindcss-uswds/issues"
   },
   "homepage": "https://github.com/hursey013/tailwindcss-uswds#readme",
-  "devDependencies": {}
+  "devDependencies": {
+    "rimraf": "^3.0.2"
+  }
 }


### PR DESCRIPTION
Currently, `rm` won't work on Windows. When you try to install the package from NPM on Windows, it just fails. This PR adds support for cross-platform builds by using the [rimraf](https://github.com/isaacs/rimraf) package. 